### PR TITLE
bind fetch for browsers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,1 +1,1 @@
-module.exports = globalThis.fetch;
+module.exports = globalThis.fetch.bind(globalThis);


### PR DESCRIPTION
Fetch doesn't work in browsers when it's not bound to the window — for example, `fetch.call({}, "...")` raises `TypeError: Can only call Window.fetch on instances of Window` in Safari and `TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation` in Chrome.

Webpack currently generates something that looks like:
```ts
const just_fetch_1 = tslib_1.__importDefault(require("@foxglove/just-fetch"));
...
await just_fetch_1.default(...)
```
And this means the fetch function executes with `this` being just_fetch_1 rather than window.

I'm not sure how Webpack normally handles issues like this (see also https://github.com/developit/unfetch/issues/46) but we can work around it with an explicit bind.