### PR TITLE
Remove incorrect typeof

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,2 +1,2 @@
-const fetch = typeof globalThis.fetch;
+const fetch = globalThis.fetch;
 export default fetch;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/637671/125114016-427ee880-e09e-11eb-83fd-9f611a35abb8.png)

After:

![image](https://user-images.githubusercontent.com/637671/125114195-7eb24900-e09e-11eb-9704-509feb677f20.png)

Still unclear whether typescript will ever import `browser.d.ts` or whether it will always use `node.d.ts`. But as long as this file is here we may as well export a sensible type.