### PR TITLE
Use dynamic import() instead of require(), node-fetch is ESM-only

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,1 +1,2 @@
-module.exports = require("node-fetch");
+module.exports = (...args) =>
+  import("node-fetch").then(({ default: fetch }) => fetch(...args));


### PR DESCRIPTION
**Public-Facing Changes**
- Fixes node.js usage of @foxglove/just-fetch by dynamically importing the ESM-only node-fetch library
