### PR TITLE
Upgrade to Yarn 4.12.0 for npm trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foxglove/just-fetch",
   "version": "1.3.1",
-  "packageManager": "yarn@4.9.1",
+  "packageManager": "yarn@4.12.0",
   "description": "Isomorphic ponyfill wrapping native browser fetch and node-fetch",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Upgrade packageManager to yarn@4.12.0

Yarn 4.10.0+ adds OIDC authentication support for GitHub Actions and GitLab CI, enabling npm trusted publishing without long-lived tokens.

## Test plan

- CI passes

Made with [Cursor](https://cursor.com)